### PR TITLE
fix(services): preserve service call data through coordinator data fetch

### DIFF
--- a/custom_components/tibber_prices/services/find_cheapest_block.py
+++ b/custom_components/tibber_prices/services/find_cheapest_block.py
@@ -267,8 +267,11 @@ async def _handle_find_block(
     # Round up to nearest quarter-hour interval
     duration_minutes = math.ceil(duration_minutes_requested / INTERVAL_MINUTES) * INTERVAL_MINUTES
 
-    entry, coordinator, data = get_entry_and_data(hass, entry_id)
-    rating_lookup = build_rating_lookup(data)
+    # Note: rebind to coordinator_data — `data` (the resolved service call
+    # data) is still needed below for validate_search_params() and
+    # apply_must_finish_by(), which read search-range parameters from it.
+    entry, coordinator, coordinator_data = get_entry_and_data(hass, entry_id)
+    rating_lookup = build_rating_lookup(coordinator_data)
 
     home_id = entry.data.get("home_id")
     if not home_id:

--- a/custom_components/tibber_prices/services/find_cheapest_hours.py
+++ b/custom_components/tibber_prices/services/find_cheapest_hours.py
@@ -329,8 +329,11 @@ async def _handle_find_hours(
     total_minutes = math.ceil(total_minutes_requested / INTERVAL_MINUTES) * INTERVAL_MINUTES
     min_segment_minutes = math.ceil(min_segment_minutes_requested / INTERVAL_MINUTES) * INTERVAL_MINUTES
 
-    entry, coordinator, data = get_entry_and_data(hass, entry_id)
-    rating_lookup = build_rating_lookup(data)
+    # Note: rebind to coordinator_data — `data` (the resolved service call
+    # data) is still needed below for validate_search_params() and
+    # apply_must_finish_by(), which read search-range parameters from it.
+    entry, coordinator, coordinator_data = get_entry_and_data(hass, entry_id)
+    rating_lookup = build_rating_lookup(coordinator_data)
 
     home_id = entry.data.get("home_id")
     if not home_id:

--- a/custom_components/tibber_prices/services/find_cheapest_schedule.py
+++ b/custom_components/tibber_prices/services/find_cheapest_schedule.py
@@ -406,8 +406,8 @@ async def handle_find_cheapest_schedule(call: ServiceCall) -> ServiceResponse:
     # Round gap up to nearest quarter interval
     gap_intervals = math.ceil(gap_minutes / INTERVAL_MINUTES) if gap_minutes > 0 else 0
 
-    entry, coordinator, data = get_entry_and_data(hass, entry_id)
-    rating_lookup = build_rating_lookup(data)
+    entry, coordinator, coordinator_data = get_entry_and_data(hass, entry_id)
+    rating_lookup = build_rating_lookup(coordinator_data)
 
     home_id = entry.data.get("home_id")
     if not home_id:

--- a/tests/services/test_find_service_responses.py
+++ b/tests/services/test_find_service_responses.py
@@ -297,3 +297,107 @@ async def test_schedule_handler_adds_per_task_comparison_details(monkeypatch: py
     assert "comparison_price_min" in comparison
     assert "comparison_price_max" in comparison
     assert "comparison_window_end" in comparison
+
+
+@pytest.mark.asyncio
+async def test_block_handler_preserves_service_search_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Block handler must pass resolved call data (not coordinator data) into search helpers."""
+    intervals = _make_intervals([10.0, 11.0, 12.0, 13.0])
+    fake_tuple = _build_fake_entry_and_coordinator(intervals)
+    deadline = datetime(2026, 1, 1, 8, 0, tzinfo=UTC)
+    fixed_start = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+
+    monkeypatch.setattr(block_module, "get_entry_and_data", lambda _hass, _entry_id: fake_tuple)
+    monkeypatch.setattr(block_module, "resolve_home_timezone", lambda _coord, _home_id: "UTC")
+
+    def _validate_search_params(call_data: dict[str, Any]) -> None:
+        assert call_data["must_finish_by"] == deadline
+        assert call_data["include_current_interval"] is False
+
+    def _apply_must_finish_by(call_data: dict[str, Any], _home_tz: Any) -> tuple[dict[str, Any], datetime]:
+        assert call_data["must_finish_by"] == deadline
+        modified = dict(call_data)
+        modified["search_end"] = deadline
+        modified.pop("must_finish_by", None)
+        return modified, deadline
+
+    def _resolve_search_range(call_data: dict[str, Any], _now: datetime, _home_tz: Any) -> tuple[datetime, datetime]:
+        assert call_data["include_current_interval"] is False
+        assert call_data["search_end"] == deadline
+        return fixed_start, deadline
+
+    async def _fetch_intervals(*_args: Any, **_kwargs: Any) -> tuple[list[dict[str, Any]], bool]:
+        return [], False
+
+    monkeypatch.setattr(block_module, "validate_search_params", _validate_search_params)
+    monkeypatch.setattr(block_module, "apply_must_finish_by", _apply_must_finish_by)
+    monkeypatch.setattr(block_module, "resolve_search_range", _resolve_search_range)
+    monkeypatch.setattr(block_module, "async_fetch_service_intervals", _fetch_intervals)
+
+    call = SimpleNamespace(
+        hass=object(),
+        data={
+            "duration": timedelta(hours=1),
+            "use_base_unit": True,
+            "must_finish_by": deadline,
+            "include_current_interval": False,
+        },
+    )
+
+    response = cast("dict[str, Any]", await handle_find_cheapest_block(cast("ServiceCall", call)))
+    assert response["success"] is False
+    assert response["search_start"] == fixed_start.isoformat()
+    assert response["search_end"] == deadline.isoformat()
+    assert response["must_finish_by"] == deadline.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_hours_handler_preserves_service_search_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hours handler must pass resolved call data (not coordinator data) into search helpers."""
+    intervals = _make_intervals([10.0, 11.0, 12.0, 13.0])
+    fake_tuple = _build_fake_entry_and_coordinator(intervals)
+    deadline = datetime(2026, 1, 1, 8, 0, tzinfo=UTC)
+    fixed_start = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+
+    monkeypatch.setattr(hours_module, "get_entry_and_data", lambda _hass, _entry_id: fake_tuple)
+    monkeypatch.setattr(hours_module, "resolve_home_timezone", lambda _coord, _home_id: "UTC")
+
+    def _validate_search_params(call_data: dict[str, Any]) -> None:
+        assert call_data["must_finish_by"] == deadline
+        assert call_data["include_current_interval"] is False
+
+    def _apply_must_finish_by(call_data: dict[str, Any], _home_tz: Any) -> tuple[dict[str, Any], datetime]:
+        assert call_data["must_finish_by"] == deadline
+        modified = dict(call_data)
+        modified["search_end"] = deadline
+        modified.pop("must_finish_by", None)
+        return modified, deadline
+
+    def _resolve_search_range(call_data: dict[str, Any], _now: datetime, _home_tz: Any) -> tuple[datetime, datetime]:
+        assert call_data["include_current_interval"] is False
+        assert call_data["search_end"] == deadline
+        return fixed_start, deadline
+
+    async def _fetch_intervals(*_args: Any, **_kwargs: Any) -> tuple[list[dict[str, Any]], bool]:
+        return [], False
+
+    monkeypatch.setattr(hours_module, "validate_search_params", _validate_search_params)
+    monkeypatch.setattr(hours_module, "apply_must_finish_by", _apply_must_finish_by)
+    monkeypatch.setattr(hours_module, "resolve_search_range", _resolve_search_range)
+    monkeypatch.setattr(hours_module, "async_fetch_service_intervals", _fetch_intervals)
+
+    call = SimpleNamespace(
+        hass=object(),
+        data={
+            "duration": timedelta(hours=1),
+            "use_base_unit": True,
+            "must_finish_by": deadline,
+            "include_current_interval": False,
+        },
+    )
+
+    response = cast("dict[str, Any]", await handle_find_cheapest_hours(cast("ServiceCall", call)))
+    assert response["success"] is False
+    assert response["search_start"] == fixed_start.isoformat()
+    assert response["search_end"] == deadline.isoformat()
+    assert response["must_finish_by"] == deadline.isoformat()


### PR DESCRIPTION
## Summary

In `_handle_find_block` and `_handle_find_hours`, the local `data` variable holding the resolved service call data is rebound to the coordinator data dict returned by `get_entry_and_data()`. As a result, the subsequent `validate_search_params(data)`, `apply_must_finish_by(data, ...)` and `resolve_search_range(...)` calls read search-range parameters from the coordinator data instead of from the service call, silently ignoring:

- `must_finish_by`
- `search_scope`
- `search_start`, `search_end`
- `search_start_time`, `search_end_time`
- `search_start_day_offset`, `search_end_day_offset`
- `search_start_offset_minutes`, `search_end_offset_minutes`
- `include_current_interval`

The handlers then fall back to the default range ("now → end of tomorrow") for every call that depended on these parameters. `find_cheapest_schedule.py` already uses `data_dict` for the same purpose and is not affected.

## Reproduction

On v0.31.0 (and current main), calling:

```yaml
action: tibber_prices.find_cheapest_block
data:
  duration:
    minutes: 120
  include_current_interval: false
  must_finish_by: "2026-06-01T08:00:00+02:00"
response_variable: plan
```

Returns:

```json
{
  "search_start": "2026-05-31T14:45:00+02:00",
  "search_end": "2026-06-02T00:00:00+02:00",
  "must_finish_by": null,
  "include_current_interval": ... (defaulted to true)
}
```

`search_end` is end-of-tomorrow (the `resolve_search_range` default), not the requested deadline. `must_finish_by` is `null` in the response because `apply_must_finish_by` never sees it on coordinator data.

## Fix

Rename the third return value of `get_entry_and_data()` to `coordinator_data` in the two affected handlers, so the service call `data` survives for the downstream `validate_search_params`, `apply_must_finish_by` and `resolve_search_range` calls.

After the fix, the same call returns:

```json
{
  "search_start": "2026-05-31T15:00:54+02:00",
  "search_end": "2026-06-01T08:00:00+02:00",
  "must_finish_by": "2026-06-01T08:00:00+02:00"
}
```

## Test plan

- [x] Verified locally on v0.31.0: `tibber_prices.find_cheapest_block` with `must_finish_by` now produces matching `search_end` in the response (previously `null`/default).
- [x] Verified locally on v0.31.0: `tibber_prices.find_cheapest_block` with `include_current_interval: false` now actually excludes the current quarter (`search_start` is `now`, not `floor_to_quarter_hour(now)`).
- [x] `find_cheapest_schedule.py` unaffected — already uses `data_dict` for the call data and `data` for coordinator data.
- [ ] Existing `tests/services/test_search_range.py` covers `resolve_search_range()` directly but not the service handlers — that is why the regression slipped through. Consider adding an end-to-end test that calls the registered service with `must_finish_by` and asserts the response echoes the deadline.

## Notes

Original report came from debugging a Home Assistant script that uses `find_cheapest_block` with a Miele washing machine deferred-start as the deadline. The deadline was silently ignored — the planner always returned the cheapest window anywhere in the next ~36h. The fix is a one-line rename per handler.